### PR TITLE
Add option to mute notifications and add 'Spotify' to notifications

### DIFF
--- a/NotificationToaster.ps1
+++ b/NotificationToaster.ps1
@@ -58,6 +58,7 @@ function ToastIt {
 			<text>$TitleVar</text>
 			<text>$ContextVar</text>
 			$size
+			<text placement="attribution">Spotify</text>
 		</binding>
 	</visual>
 	$silent

--- a/NotificationToaster.ps1
+++ b/NotificationToaster.ps1
@@ -9,6 +9,7 @@ $ToastXml = New-Object -TypeName Windows.Data.Xml.Dom.XmlDocument
 
 $appLogoOverrideVar = [System.Web.HttpUtility]::HtmlEncode($RmAPI.VariableStr("NotificationIcon"))
 $isBigSize = $RmAPI.Variable("Big") -eq 1
+$isSilent = $RmAPI.Variable("Silent") -eq 1
 function EncodeVar {
 	param([string]$name)
     $variableValue = $RmAPI.MeasureStr($name)
@@ -38,6 +39,16 @@ function ToastIt {
 	<image placement="appLogoOverride" hint-crop="circle" src="$HeroImageVar"/>
 "@
 	})
+	
+	$silent = $(if ($isSilent) {
+	@"
+	<audio silent="true"/>
+"@
+	} else {
+	@"
+	<audio silent="false"/>
+"@
+	})
 
     $RmAPI.log($size)
 [xml]$ToastTemplate = @"
@@ -49,6 +60,7 @@ function ToastIt {
 			$size
 		</binding>
 	</visual>
+	$silent
 </toast>
 "@
 

--- a/ToastSpotify.ini
+++ b/ToastSpotify.ini
@@ -11,6 +11,7 @@ License=MIT
 [Variables]
 NotificationIcon=#CurrentPath#spotify.png
 Big = 0
+Silent = 1
 
 [DummyMeter]
 Meter=String


### PR DESCRIPTION
Adds an option to mute the notifcation so it doesn't trigger the normal Windows notification sound while you're listening to music (enabled by default). Also adds the word 'Spotify' to the notification text next to the word 'Rainmeter'.